### PR TITLE
Add unit declarator to class declarations

### DIFF
--- a/lib/Algorithm/Viterbi.pm
+++ b/lib/Algorithm/Viterbi.pm
@@ -1,6 +1,6 @@
 use v6;
 
-class Algorithm::Viterbi;
+unit class Algorithm::Viterbi;
 
 #our class Start {};
 #our class End {};


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.
