### PR TITLE
Add missing "provides" in META

### DIFF
--- a/META.info
+++ b/META.info
@@ -2,6 +2,9 @@
     "name": "Algorithm::Viterbi",
     "description": "HMM decoding with the Viterbi algorithm.",
     "version": "*",
+    "provides" : {
+       "Algorithm::Viterbi" : "lib/Algorithm/Viterbi.pm"
+    },
     "depends": [],
     "source-url": "git://github.com/arnsholt/Algorithm-Viterbi.git",
     "source-type": "git"


### PR DESCRIPTION
We were just reviewing the log of the modules list builder.
